### PR TITLE
Update to maven-shared-filtering 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,9 +285,7 @@
                     <linkXRef>true</linkXRef>
                     <sourceEncoding>utf-8</sourceEncoding>
                     <rulesets>
-                        <ruleset>/rulesets/java/basic.xml</ruleset>
-                        <ruleset>/rulesets/java/imports.xml</ruleset>
-                        <ruleset>/rulesets/java/unusedcode.xml</ruleset>
+                        <ruleset>${project.basedir}/src/main/config/pmdrules.xml</ruleset>
                     </rulesets>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,26 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.2.5</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
                 <version>${plexus-component-metadata.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <doxia-module-markdown.version>1.7</doxia-module-markdown.version>
         <plexus-component-metadata.version>1.7.1</plexus-component-metadata.version>
         <junit.version>4.12</junit.version>
-        <hamcrest-core.version>1.3</hamcrest-core.version>
         <checkstyle-plugin.version>3.0.0</checkstyle-plugin.version>
         <pmd-plugin.version>3.8</pmd-plugin.version>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
@@ -101,12 +100,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.owasp.maven-tools</groupId>
     <artifactId>velocity-whitespace-resource-filter</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <inceptionYear>2018</inceptionYear>
     <name>velocity-whitespace-resource-filter</name>
@@ -53,7 +53,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.api.version>3.1.0</maven.api.version>
         <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
         <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
@@ -76,7 +75,22 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-filtering</artifactId>
-            <version>${maven.api.version}</version>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-component-annotations</artifactId>
+            <version>1.5.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.owasp.maven-tools</groupId>
     <artifactId>velocity-whitespace-resource-filter</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <inceptionYear>2018</inceptionYear>
     <name>velocity-whitespace-resource-filter</name>
@@ -75,12 +75,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-filtering</artifactId>
-            <version>3.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-shared-utils</artifactId>
-            <version>3.0.0</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -102,6 +97,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>${hamcrest-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -53,22 +53,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
-        <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
-        <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
-        <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
-        <maven-surefire-report-plugin.version>2.20.1</maven-surefire-report-plugin.version>
-        <maven.invoker.plugin.version>3.0.1</maven.invoker.plugin.version>
-        <maven.site.plugin.version>3.7</maven.site.plugin.version>
-        <doxia-module-markdown.version>1.7</doxia-module-markdown.version>
-        <plexus-component-metadata.version>1.7.1</plexus-component-metadata.version>
+        <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
+        <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
+        <maven-jxr-plugin.version>3.2.0</maven-jxr-plugin.version>
+        <maven-project-info-reports-plugin.version>3.4.0</maven-project-info-reports-plugin.version>
+        <maven-surefire-report-plugin.version>3.0.0-M7</maven-surefire-report-plugin.version>
+        <maven.invoker.plugin.version>3.3.0</maven.invoker.plugin.version>
+        <maven.site.plugin.version>3.12.0</maven.site.plugin.version>
+        <doxia-module-markdown.version>1.11.1</doxia-module-markdown.version>
+        <plexus-component-metadata.version>2.1.1</plexus-component-metadata.version>
         <junit.version>4.12</junit.version>
-        <checkstyle-plugin.version>3.0.0</checkstyle-plugin.version>
-        <pmd-plugin.version>3.8</pmd-plugin.version>
-        <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
+        <checkstyle-plugin.version>3.1.2</checkstyle-plugin.version>
+        <pmd-plugin.version>3.17.0</pmd-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
-        <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
-        <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
+        <taglist-maven-plugin.version>3.0.0</taglist-maven-plugin.version>
+        <versions-maven-plugin.version>2.11.0</versions-maven-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -299,12 +299,12 @@
                     <reportSet>
                         <reports>
                             <report>index</report>
-                            <report>cim</report>
+                            <report>ci-management</report>
                             <report>summary</report>
-                            <report>issue-tracking</report>
-                            <report>project-team</report>
+                            <report>issue-management</report>
+                            <report>team</report>
                             <report>scm</report>
-                            <report>license</report>
+                            <report>licenses</report>
                         </reports>
                     </reportSet>
                 </reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,16 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+            <version>0.0.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-filtering</artifactId>
             <version>3.3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -337,9 +337,9 @@
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs-maven-plugin.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.7.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/src/it/resource-filter-test/pom.xml
+++ b/src/it/resource-filter-test/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.owasp.maven-tools</groupId>

--- a/src/it/resource-filter-test/postbuild.groovy
+++ b/src/it/resource-filter-test/postbuild.groovy
@@ -29,13 +29,13 @@ if (!FileUtils.contentEquals(file1, file2)) {
 file1 = new File(basedir, "src/main/resources/template.txt");
 file2 = new File(basedir, "target/classes/template.txt");
 if (!FileUtils.contentEquals(file1, file2)) {
-    System.out.println("template.txt in src does not match template.vm in target/classes");
+    System.out.println("template.txt in src does not match template.txt in target/classes");
     return false;
 }
 
 file1 = new File(basedir, "src/main/resources/template.vtl");
 file2 = new File(basedir, "target/classes/template.vtl");
 if (FileUtils.contentEquals(file1, file2)) {
-    System.out.println("template.vtl in target/classes was NOT FILTERED and matches template.vm in src");
+    System.out.println("template.vtl in target/classes was NOT FILTERED and matches template.vtl in src");
     return false;
 }

--- a/src/main/config/checkstyle-checks.xml
+++ b/src/main/config/checkstyle-checks.xml
@@ -18,7 +18,12 @@
         <property name="file" value="${checkstyle.suppressions.file}"/>
     </module>
 
-    <module name="SuppressionCommentFilter">
+    <module name="LineLength">
+        <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
+        <property name="max" value="150"/>
+    </module>
+
+    <module name="SuppressWithPlainTextCommentFilter">
         <property name="offCommentFormat" value="CSOFF\: ([\w\|]+)"/>
         <property name="onCommentFormat" value="CSON\: ([\w\|]+)"/>
         <property name="checkFormat" value="$1"/>
@@ -58,7 +63,6 @@
 
     <module name="TreeWalker">
         <property name="tabWidth" value="4"/>
-        <module name="FileContentsHolder"/>
         <module name="AvoidStarImport"/>
         <module name="ConstantName"/>
         <module name="EmptyBlock"/>
@@ -77,9 +81,8 @@
         <module name="JavadocType">
             <property name="authorFormat" value="\S"/>
         </module>
-        <module name="JavadocMethod">
-            <property name="allowUndeclaredRTE" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        <module name="JavadocMethod"/>
+        <module name="MissingJavadocMethod">
             <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
         <module name="JavadocVariable"/>
@@ -106,10 +109,6 @@
         </module>
 
         <module name="OuterTypeNumber"/>
-        <module name="LineLength">
-            <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
-            <property name="max" value="150"/>
-        </module>
 
         <module name="MethodCount">
             <property name="maxTotal" value="80"/>

--- a/src/main/config/pmdrules.xml
+++ b/src/main/config/pmdrules.xml
@@ -12,7 +12,7 @@
         Saved locally in preparation of the removal of the rulesets in PMD 7
     </description>
 
-    <!-- region The rules of the deprecated basic.xml PMD ruleset -->
+    <!-- region The rules of the deprecated basic.xml PMD ruleset  updated for deprecations -->
     <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
     <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" />
     <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" />
@@ -38,18 +38,14 @@
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
 
     <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
-    <rule ref="category/java/performance.xml/BooleanInstantiation" />
+    <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation" />
 
     <rule ref="category/java/design.xml/CollapsibleIfStatements" />
     <rule ref="category/java/design.xml/SimplifiedTernary" />
     <!-- endregion -->
-    <!-- region The rules of the deprecated imports PMD ruleset -->
-    <rule ref="category/java/bestpractices.xml/UnusedImports" />
+    <!-- region The rules of the deprecated imports PMD ruleset updated for deprecations-->
+    <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
 
-    <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />
-
-    <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
-    <rule ref="category/java/codestyle.xml/DuplicateImports" />
     <rule ref="category/java/codestyle.xml/TooManyStaticImports" />
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
     <!-- endregion -->

--- a/src/main/config/pmdrules.xml
+++ b/src/main/config/pmdrules.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+
+<ruleset name="basic-imports-unusedcode"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>
+        The junction of the following deprecated PMD rulesets:
+        * basic: Basic ruleset contains a collection of good practices which should be followed.
+        * imports: These rules deal with different problems that can occur with import statements.
+        * unusedcode: The Unused Code ruleset contains rules that find unused or ineffective code.
+        Saved locally in preparation of the removal of the rulesets in PMD 7
+    </description>
+
+    <!-- region The rules of the deprecated basic.xml PMD ruleset -->
+    <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
+    <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" />
+    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" />
+    <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues" />
+    <rule ref="category/java/errorprone.xml/BrokenNullCheck" />
+    <rule ref="category/java/errorprone.xml/CheckSkipResult" />
+    <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray" />
+    <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" />
+    <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
+    <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
+    <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" />
+    <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock" />
+    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
+
+    <rule ref="category/java/multithreading.xml/AvoidThreadGroup" />
+    <rule ref="category/java/multithreading.xml/DontCallThreadRun" />
+    <rule ref="category/java/multithreading.xml/DoubleCheckedLocking" />
+
+    <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />
+    <rule ref="category/java/bestpractices.xml/CheckResultSet" />
+
+    <rule ref="category/java/codestyle.xml/ExtendsObject" />
+    <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
+
+    <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
+    <rule ref="category/java/performance.xml/BooleanInstantiation" />
+
+    <rule ref="category/java/design.xml/CollapsibleIfStatements" />
+    <rule ref="category/java/design.xml/SimplifiedTernary" />
+    <!-- endregion -->
+    <!-- region The rules of the deprecated imports PMD ruleset -->
+    <rule ref="category/java/bestpractices.xml/UnusedImports" />
+
+    <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />
+
+    <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
+    <rule ref="category/java/codestyle.xml/DuplicateImports" />
+    <rule ref="category/java/codestyle.xml/TooManyStaticImports" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
+    <!-- endregion -->
+    <!-- region The rules of the deprecated unusedcode PMD ruleset -->
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
+    <!-- endregion -->
+
+</ruleset>

--- a/src/main/java/org/owasp/maven/tools/VelocityWhitespaceFilter.java
+++ b/src/main/java/org/owasp/maven/tools/VelocityWhitespaceFilter.java
@@ -45,6 +45,11 @@ public class VelocityWhitespaceFilter extends DefaultMavenFileFilter {
      */
     private final List<String> extensions = Arrays.asList("vm", "vtl", "vsl");
 
+    /**
+     * Constructs a VelocityWhitespaceFilter.
+     *
+     * @param buildContext The buildContext (injected by Maven)
+     */
     @Inject
     public VelocityWhitespaceFilter(final BuildContext buildContext) {
         super(buildContext);

--- a/src/main/java/org/owasp/maven/tools/VelocityWhitespaceFilter.java
+++ b/src/main/java/org/owasp/maven/tools/VelocityWhitespaceFilter.java
@@ -21,10 +21,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.shared.filtering.DefaultMavenFileFilter;
+import org.apache.maven.shared.filtering.FilterWrapper;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.codehaus.plexus.component.annotations.Component;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import javax.inject.Inject;
 
 /**
  * Simple resource filter that is used to remove excess whitespace from Velocity
@@ -41,6 +44,11 @@ public class VelocityWhitespaceFilter extends DefaultMavenFileFilter {
      * The extensions that are supported.
      */
     private final List<String> extensions = Arrays.asList("vm", "vtl", "vsl");
+
+    @Inject
+    public VelocityWhitespaceFilter(final BuildContext buildContext) {
+        super(buildContext);
+    }
 
     /**
      * Whether or not the given file should be filtered.
@@ -62,9 +70,9 @@ public class VelocityWhitespaceFilter extends DefaultMavenFileFilter {
      * the Velocity Template copied will output less whitespace.
      */
     @Override
-    public void copyFile(File from, File to, boolean filtering, List<FileUtils.FilterWrapper> filterWrappers,
+    public void copyFile(File from, File to, boolean filtering, List<FilterWrapper> filterWrappers,
             String encoding, boolean overwrite) throws MavenFilteringException {
-        List<FileUtils.FilterWrapper> wrappers = filterWrappers;
+        List<FilterWrapper> wrappers = filterWrappers;
         if (filtering && shouldFilter(from)) {
             wrappers = new ArrayList<>(filterWrappers);
             wrappers.add(new VelocityWhitespaceFilterWrapper());

--- a/src/main/java/org/owasp/maven/tools/VelocityWhitespaceFilterWrapper.java
+++ b/src/main/java/org/owasp/maven/tools/VelocityWhitespaceFilterWrapper.java
@@ -16,7 +16,7 @@
 package org.owasp.maven.tools;
 
 import java.io.Reader;
-import org.apache.maven.shared.utils.io.FileUtils;
+import org.apache.maven.shared.filtering.FilterWrapper;
 
 /**
  * A Maven Filter Wrapper used to add the
@@ -25,7 +25,7 @@ import org.apache.maven.shared.utils.io.FileUtils;
  *
  * @author Jeremy Long
  */
-public class VelocityWhitespaceFilterWrapper extends FileUtils.FilterWrapper {
+public class VelocityWhitespaceFilterWrapper extends FilterWrapper {
 
     /**
      * {@inheritDoc}

--- a/src/test/java/org/owasp/maven/tools/VelocityWhitespaceFilterTest.java
+++ b/src/test/java/org/owasp/maven/tools/VelocityWhitespaceFilterTest.java
@@ -17,6 +17,9 @@ package org.owasp.maven.tools;
 
 import java.io.File;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
 import static org.junit.Assert.*;
 
 /**
@@ -30,7 +33,7 @@ public class VelocityWhitespaceFilterTest {
      */
     @Test
     public void testShouldFilter() {
-        VelocityWhitespaceFilter instance = new VelocityWhitespaceFilter();
+        VelocityWhitespaceFilter instance = new VelocityWhitespaceFilter(Mockito.mock(BuildContext.class));
         File from = null;
         boolean expResult = false;
         boolean result = instance.shouldFilter(from);


### PR DESCRIPTION
Maven Shared maven-filtering library updated the API in a backward incompatible way (causing failure of the dependabot PR in OWASP DependencyCheck for upgrade of maven-resources-plugin from 3.2.0 to 3.3.0, which includes an update to maven-shared-filtering 3.3.0 for filtered resources).

As this is a breaking API change the updated sources require maven-shared-filtering to be updated at the same time, so I bumped the major version.